### PR TITLE
Add defaults by vehicle class and integrate into Streamlit app

### DIFF
--- a/data/processed/defaults_by_class.json
+++ b/data/processed/defaults_by_class.json
@@ -1,0 +1,98 @@
+{
+  "mini": {
+    "ICE": {
+      "purchase_price": 28000,
+      "residual_rate_8y_hint": 0.32,
+      "consumption_fuel_l_per_100": 5.2,
+      "maint_6y_chf": 2600,
+      "tires_base_chf": 900
+    },
+    "BEV": {
+      "purchase_price": 35000,
+      "residual_rate_8y_hint": 0.38,
+      "consumption_elec_kwh_per_100": 14.5,
+      "maint_6y_chf": 2400,
+      "tires_base_chf": 900
+    },
+    "PHEV": {
+      "purchase_price": 33000,
+      "residual_rate_8y_hint": 0.35,
+      "consumption_fuel_l_per_100": 4.2,
+      "consumption_elec_kwh_per_100": 13.5,
+      "maint_6y_chf": 2500,
+      "tires_base_chf": 900
+    }
+  },
+  "compact": {
+    "ICE": {
+      "purchase_price": 35000,
+      "residual_rate_8y_hint": 0.30,
+      "consumption_fuel_l_per_100": 6.0,
+      "maint_6y_chf": 3000,
+      "tires_base_chf": 950
+    },
+    "BEV": {
+      "purchase_price": 45000,
+      "residual_rate_8y_hint": 0.36,
+      "consumption_elec_kwh_per_100": 16.5,
+      "maint_6y_chf": 2700,
+      "tires_base_chf": 950
+    },
+    "PHEV": {
+      "purchase_price": 43000,
+      "residual_rate_8y_hint": 0.33,
+      "consumption_fuel_l_per_100": 4.8,
+      "consumption_elec_kwh_per_100": 15.5,
+      "maint_6y_chf": 2900,
+      "tires_base_chf": 950
+    }
+  },
+  "midsize": {
+    "ICE": {
+      "purchase_price": 42000,
+      "residual_rate_8y_hint": 0.28,
+      "consumption_fuel_l_per_100": 6.8,
+      "maint_6y_chf": 3200,
+      "tires_base_chf": 1000
+    },
+    "BEV": {
+      "purchase_price": 55000,
+      "residual_rate_8y_hint": 0.35,
+      "consumption_elec_kwh_per_100": 17.0,
+      "maint_6y_chf": 2800,
+      "tires_base_chf": 1000
+    },
+    "PHEV": {
+      "purchase_price": 52000,
+      "residual_rate_8y_hint": 0.32,
+      "consumption_fuel_l_per_100": 5.0,
+      "consumption_elec_kwh_per_100": 16.0,
+      "maint_6y_chf": 3000,
+      "tires_base_chf": 1000
+    }
+  },
+  "suv": {
+    "ICE": {
+      "purchase_price": 60000,
+      "residual_rate_8y_hint": 0.26,
+      "consumption_fuel_l_per_100": 8.5,
+      "maint_6y_chf": 3600,
+      "tires_base_chf": 1100
+    },
+    "BEV": {
+      "purchase_price": 68000,
+      "residual_rate_8y_hint": 0.33,
+      "consumption_elec_kwh_per_100": 21.0,
+      "maint_6y_chf": 3200,
+      "tires_base_chf": 1100
+    },
+    "PHEV": {
+      "purchase_price": 65000,
+      "residual_rate_8y_hint": 0.30,
+      "consumption_fuel_l_per_100": 6.5,
+      "consumption_elec_kwh_per_100": 19.0,
+      "maint_6y_chf": 3400,
+      "tires_base_chf": 1100
+    }
+  }
+}

--- a/tco_core/defaults.py
+++ b/tco_core/defaults.py
@@ -1,0 +1,129 @@
+"""Utilities to load and access vehicle defaults grouped by class/technology."""
+from __future__ import annotations
+
+import copy
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Mapping, MutableMapping
+
+from .models import Tech
+
+_PACKAGE_ROOT = Path(__file__).resolve().parent
+_DEFAULTS_PATH = _PACKAGE_ROOT.parent / "data" / "processed" / "defaults_by_class.json"
+
+
+@lru_cache(maxsize=None)
+def _load_defaults_cached(path_str: str) -> Dict[str, Any]:
+    path = Path(path_str)
+    if not path.exists():
+        raise FileNotFoundError(f"Defaults file not found: {path}")
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def load_defaults_by_class(path: str | Path | None = None) -> Dict[str, Any]:
+    """Return the defaults grouped by vehicle class.
+
+    Parameters
+    ----------
+    path:
+        Optional path to the JSON file. When omitted, the project-level defaults
+        file located under ``data/processed/defaults_by_class.json`` is used.
+
+    Returns
+    -------
+    dict
+        A *deep copy* of the defaults structure so callers can manipulate the
+        returned mapping without mutating the cached data.
+    """
+
+    resolved_path = Path(path) if path is not None else _DEFAULTS_PATH
+    data = _load_defaults_cached(str(resolved_path))
+    return copy.deepcopy(data)
+
+
+def _normalize_vehicle_class(defaults: Mapping[str, Any], vehicle_class: str) -> str:
+    lookup = vehicle_class.lower()
+    for key in defaults:
+        if key.lower() == lookup:
+            return key
+    raise KeyError(f"Unknown vehicle class '{vehicle_class}' (available: {', '.join(defaults)})")
+
+
+def _normalize_tech(tech: Tech | str) -> str:
+    if isinstance(tech, Tech):
+        return tech.value
+    return str(tech).upper()
+
+
+def get_defaults(
+    tech: Tech | str,
+    vehicle_class: str,
+    defaults_by_class: Mapping[str, Any] | None = None,
+) -> Dict[str, Any]:
+    """Return defaults for a given (technology, vehicle class) pair.
+
+    Parameters
+    ----------
+    tech:
+        Either a :class:`tco_core.models.Tech` member or its string name.
+    vehicle_class:
+        The vehicle class identifier (case insensitive).
+    defaults_by_class:
+        Optional mapping already loaded via :func:`load_defaults_by_class`.
+
+    Returns
+    -------
+    dict
+        A dictionary copy with the defaults for the requested pair.
+    """
+
+    defaults = defaults_by_class or load_defaults_by_class()
+    class_key = _normalize_vehicle_class(defaults, vehicle_class)
+    tech_key = _normalize_tech(tech)
+
+    try:
+        tech_defaults = defaults[class_key][tech_key]
+    except KeyError as exc:
+        available = ", ".join(defaults[class_key])
+        raise KeyError(
+            f"Unknown tech '{tech}' for class '{class_key}' (available: {available})"
+        ) from exc
+
+    return copy.deepcopy(tech_defaults)
+
+
+def residual_rate_from_defaults(defaults: Mapping[str, Any]) -> float:
+    """Extract the residual rate from a defaults mapping."""
+
+    residual = defaults.get("residual_rate_8y")
+    if residual is None:
+        residual = defaults.get("residual_rate_8y_hint")
+    if residual is None:
+        raise KeyError("Defaults mapping does not contain 'residual_rate_8y' or 'residual_rate_8y_hint'")
+    return float(residual)
+
+
+def apply_defaults(
+    spec: MutableMapping[str, Any],
+    defaults: Mapping[str, Any],
+    *,
+    include_consumption: bool = True,
+) -> None:
+    """Populate a mutable mapping with defaults values.
+
+    Helper mainly used by the Streamlit app when building forms.
+    """
+
+    spec.update({
+        "purchase_price": float(defaults["purchase_price"]),
+        "residual_rate_8y": residual_rate_from_defaults(defaults),
+        "maint_6y_chf": float(defaults["maint_6y_chf"]),
+        "tires_base_chf": float(defaults["tires_base_chf"]),
+    })
+    if include_consumption:
+        if "consumption_fuel_l_per_100" in defaults:
+            spec["consumption_fuel_l_per_100"] = float(defaults["consumption_fuel_l_per_100"])
+        if "consumption_elec_kwh_per_100" in defaults:
+            spec["consumption_elec_kwh_per_100"] = float(defaults["consumption_elec_kwh_per_100"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,0 +1,53 @@
+import math
+
+import pytest
+
+from tco_core.defaults import get_defaults, load_defaults_by_class, residual_rate_from_defaults
+from tco_core.models import Tech
+
+
+@pytest.fixture(scope="module")
+def defaults():
+    return load_defaults_by_class()
+
+
+def test_load_defaults_structure(defaults):
+    classes = {"mini", "compact", "midsize", "suv"}
+    assert classes.issubset(defaults.keys())
+
+    for vehicle_class in classes:
+        tech_defaults = defaults[vehicle_class]
+        for tech in ["ICE", "BEV", "PHEV"]:
+            assert tech in tech_defaults
+            values = tech_defaults[tech]
+            assert "purchase_price" in values
+            assert "residual_rate_8y_hint" in values or "residual_rate_8y" in values
+            assert "maint_6y_chf" in values
+            assert "tires_base_chf" in values
+            if tech != "BEV":
+                assert "consumption_fuel_l_per_100" in values
+            if tech != "ICE":
+                assert "consumption_elec_kwh_per_100" in values
+
+
+def test_get_defaults_by_class_and_tech(defaults):
+    midsize_bev = get_defaults(Tech.BEV, "midsize", defaults)
+    assert midsize_bev == defaults["midsize"]["BEV"]
+
+    suv_phev = get_defaults("phev", "SUV", defaults)
+    assert math.isclose(suv_phev["consumption_elec_kwh_per_100"], 19.0)
+    assert math.isclose(suv_phev["purchase_price"], 65_000)
+
+
+def test_make_spec_uses_defaults():
+    from app.app import make_spec  # import inside test to avoid heavy streamlit setup at module import time
+
+    midsize_defaults = load_defaults_by_class()["midsize"]["PHEV"]
+    spec = make_spec(Tech.PHEV, "midsize")
+    assert spec.vehicle_class == "midsize"
+    assert math.isclose(spec.purchase_price, midsize_defaults["purchase_price"])
+    assert math.isclose(spec.maint_6y_chf, midsize_defaults["maint_6y_chf"])
+    assert math.isclose(spec.tires_base_chf, midsize_defaults["tires_base_chf"])
+    assert math.isclose(spec.consumption_fuel_l_per_100, midsize_defaults["consumption_fuel_l_per_100"])
+    assert math.isclose(spec.consumption_elec_kwh_per_100, midsize_defaults["consumption_elec_kwh_per_100"])
+    assert math.isclose(spec.residual_rate_8y, residual_rate_from_defaults(midsize_defaults))


### PR DESCRIPTION
## Summary
- add a processed defaults JSON covering the mini, compact, midsize, and SUV classes
- introduce `tco_core.defaults` helpers and wire the Streamlit UI to class/tech defaults
- add pytest coverage for loading defaults and ensure tests can import the package

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3ad480c248331899b70d8a7ee0c25